### PR TITLE
Set unlocalized names for power items

### DIFF
--- a/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorBoots.java
+++ b/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorBoots.java
@@ -24,6 +24,7 @@ public class ItemPowerArmorBoots extends ItemPowerArmor {
 		super(assignedItemID, // itemID
 				0, // Texture index for rendering armor on the player
 				3); // armor type. 0=head, 1=torso, 2=legs, 3=feet
+		setUnlocalizedName("powerArmorBoots");
 		LanguageRegistry.addName(this, "Power Armor Boots");
 	}
 

--- a/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorChestplate.java
+++ b/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorChestplate.java
@@ -14,6 +14,7 @@ public class ItemPowerArmorChestplate extends ItemPowerArmor {
 		super(assignedItemID, // itemID
 				0, // Texture index for rendering armor on the player
 				1); // armor type. 0=head, 1=torso, 2=legs, 3=feet
+		setUnlocalizedName("powerArmorChestplate");
 		LanguageRegistry.addName(this, "Power Armor Chestplate");
 	}
 

--- a/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorHelmet.java
+++ b/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorHelmet.java
@@ -20,6 +20,7 @@ public class ItemPowerArmorHelmet extends ItemPowerArmor implements IBreathableA
 		super(assignedItemID, // itemID
 				0, // Texture index for rendering armor on the player
 				0); // armor type. 0=head, 1=torso, 2=legs, 3=feet
+		setUnlocalizedName("powerArmorHelmet");
 		LanguageRegistry.addName(this, "Power Armor Helmet");
 	}
 

--- a/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorLeggings.java
+++ b/src/minecraft/net/machinemuse/powersuits/item/ItemPowerArmorLeggings.java
@@ -14,6 +14,7 @@ public class ItemPowerArmorLeggings extends ItemPowerArmor {
 		super(assignedItemID, // itemID
 				0, // Texture index for rendering armor on the player
 				2); // armor type. 0=head, 1=torso, 2=legs, 3=feet
+		setUnlocalizedName("powerArmorLeggings");
 		LanguageRegistry.addName(this, "Power Armor Leggings");
 	}
 

--- a/src/minecraft/net/machinemuse/powersuits/item/ItemPowerGauntlet.java
+++ b/src/minecraft/net/machinemuse/powersuits/item/ItemPowerGauntlet.java
@@ -59,6 +59,7 @@ public class ItemPowerGauntlet extends ItemElectricTool implements IModularItem 
 		setMaxDamage(0);
 		this.damageVsEntity = 1;
 		setCreativeTab(Config.getCreativeTab());
+		setUnlocalizedName("powerGauntlet");
 		LanguageRegistry.addName(this, "Power Gauntlet");
 	}
 


### PR DESCRIPTION
Power gauntlet and power armor items now set their unlocalized names in the constructor. This fixes them all showing up as "Power Gauntlet" in the interface.
