### PR TITLE
Explicitly save GL_SCISSOR_TEST to workaround driver bugs

### DIFF
--- a/src/minecraft/net/machinemuse/utils/render/MuseRenderer.java
+++ b/src/minecraft/net/machinemuse/utils/render/MuseRenderer.java
@@ -247,7 +247,7 @@ public abstract class MuseRenderer {
 
     public static void scissorsOn(double x, double y, double w, double h) {
 //        GL11.glPushAttrib(GL11.GL_VIEWPORT_BIT);
-        GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_SCISSOR_BIT);
         GL11.glPushMatrix();
         Minecraft mc = Minecraft.getMinecraft();
 


### PR DESCRIPTION
Fixes issue #314. Some OpenGL drivers don't save GL_SCISSOR_TEST with GL_ENABLE_BIT
