### PR TITLE
NPE fix for biomes with null names.

### DIFF
--- a/src/minecraft/net/machinemuse/utils/MusePlayerUtils.java
+++ b/src/minecraft/net/machinemuse/utils/MusePlayerUtils.java
@@ -333,7 +333,7 @@ public class MusePlayerUtils {
         if ((int)player.posY > 128) { // If high in the air, increase cooling
             cool += 0.5;
         }
-        if (!player.worldObj.isDaytime() && getBiome(player).biomeName.equals("Desert")) { // If nighttime and in the desert, increase cooling
+        if (!player.worldObj.isDaytime() && "Desert".equals(getBiome(player).biomeName)) { // If nighttime and in the desert, increase cooling
             cool += 0.8;
         }
         if (player.worldObj.isRaining()) {


### PR DESCRIPTION
If the biomeName is null, this throws a nasty exception (don't ask me why the name is null).  I assume getBiome(player) isn't null, because it's referenced earlier in the same function and it threw the NPE on line 336.

http://pastebin.com/t2gYMwGq
