### PR TITLE
Add a correction to a recipe to avoid errors in NEI

### DIFF
--- a/assets/powersuits/recipes/vanilla.recipes
+++ b/assets/powersuits/recipes/vanilla.recipes
@@ -175,7 +175,7 @@
 		"ingredients" : [
 			[  null, { "unlocalizedName" : "item.ingotIron" }, {"unlocalizedName" : "item.ingotIron" } ],
 			[  {"unlocalizedName" : "item.ingotIron" }, {"unlocalizedName" : "item.ingotIron" }, null],
-			[  {"unlocalizedName" : "item.ingotIron" } ]
+			[  {"unlocalizedName" : "item.ingotIron" }, null, null]
 		],
 		"result" : {
 			"oredictName" : "componentGliderWing"


### PR DESCRIPTION
Should resolve problems in the JSONRecipe system since you assume that all ingredients array have the same size in the JSONRecipeHandler (numina).
This should correct #438 #439 and #440 bugs. It should also correct the bug reported in the numina repository.
