### PR TITLE
Set minimum Numina version dynamically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,11 @@ def travisbuildnumber = (System.getenv("TRAVIS_BUILD_NUMBER") ?: -111).toInteger
 version = "${config.mod_version}." + (buildnumber ?: travisbuildnumber)
 group= "${config.group_id}" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "${config.mod_id}"
+def numina_version = (System.getenv("NUMINA_VERSION") ?:"0.4.0.131")
 
 minecraft {
     version = "${config.minecraft_version}-${config.forge_version}"
+    replace "@numina_version@", numina_version
     runDir = "run"
 }
 
@@ -71,6 +73,7 @@ getLibrary("MrTJPCore-1.1.0.31-universal.jar")
 getLibrary("ProjectRed-1.7.10-4.7.0pre8.92-Base.jar")
 getLibrary("Chisel2-2.5.0.43-deobf.jar")
 getLibrary("Chisel-2.9.0.3-deobf.jar")
+//getLibrary("compactmachines-1.7.10-1.20-dev.jar") // This is for the personal shrinking device module; needs to be built from source. 
 
 processResources {
     // this will ensure that this task is redone when the versions change.

--- a/src/main/scala/net/machinemuse/powersuits/common/ModularPowersuits.scala
+++ b/src/main/scala/net/machinemuse/powersuits/common/ModularPowersuits.scala
@@ -21,8 +21,10 @@ import net.machinemuse.powersuits.powermodule.tool.TerminalHandler;
  *
  * @author MachineMuse
  */
-@Mod(modid = "powersuits", modLanguage = "scala", dependencies = "required-after:numina@[0.4.0.131,)")
+@Mod(modid = "powersuits", modLanguage = "scala", dependencies = "required-after:numina@[" + ModularPowersuits.NuminaVersion + ",)")
 object ModularPowersuits {
+  final val NuminaVersion = "@numina_version@"
+
   @SidedProxy(clientSide = "net.machinemuse.powersuits.common.ClientProxy", serverSide = "net.machinemuse.powersuits.common.ServerProxy")
   var proxy: CommonProxy = null
   var config: Configuration = null
@@ -38,7 +40,6 @@ object ModularPowersuits {
   }
 
   @Mod.EventHandler def load(event: FMLInitializationEvent) {
-
     Config.loadPowerModules
     Config.getMaximumArmorPerPiece
     Config.getMaximumFlyingSpeedmps


### PR DESCRIPTION
This adds a way to set the minimum Numina version from the build environment as discussed: https://github.com/MachineMuse/MachineMusePowersuits/issues/641

The fallback version was set to the latest current version. 
