### PR TITLE
no oredict entry in vanilla for ice?

### DIFF
--- a/src/main/resources/mps-vanilla.recipes
+++ b/src/main/resources/mps-vanilla.recipes
@@ -285,7 +285,7 @@
 	},
 	{
 		"ingredients" : [
-			[ { "oredictName" : "blockIce" }, { "registryName" : "minecraft:packed_ice" }, { "oredictName" : "blockIce" } ],
+			[ { "registryName" : "minecraft:ice" }, { "registryName" : "minecraft:packed_ice" }, { "registryName" : "minecraft:ice" } ],
 			[ { "registryName" : "minecraft:water_bucket" }, { "registryName" : "minecraft:water_bucket" }, { "registryName" : "minecraft:water_bucket" } ],
 			[ null, { "registryName" : "minecraft:bucket" }, null ]
 		],


### PR DESCRIPTION
Apparently there is no oredict entry for ice blocks in vanilla 
