### PR TITLE
onPlayerLogin should not be static

### DIFF
--- a/src/main/java/net/machinemuse/powersuits/event/PlayerLoginHandlerThingy.java
+++ b/src/main/java/net/machinemuse/powersuits/event/PlayerLoginHandlerThingy.java
@@ -15,7 +15,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
  */
 public class PlayerLoginHandlerThingy {
     @SubscribeEvent
-    public static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent e) {
+    public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent e) {
         EntityPlayer player = e.player;
         PacketSender.sendTo(new MusePacketPropertyModifierConfig(player, null), (EntityPlayerMP)player);
     }


### PR DESCRIPTION
`onPlayerLogin` should not be static, this prevents players joining a dedicated server.